### PR TITLE
Log capacity check responses

### DIFF
--- a/bot-bromo.py
+++ b/bot-bromo.py
@@ -112,6 +112,12 @@ def check_capacity(iso_date: str) -> dict | None:
     payload = {"action": "kapasitas", "year_month": year_month, "id_site": ID_SITE}
     headers = {"User-Agent": "Mozilla/5.0"}
     resp = requests.post(CAP_URL, data=payload, headers=headers, timeout=30)
+    log.info(
+        "check_capacity response iso=%s status=%s body=%s",
+        iso_date,
+        resp.status_code,
+        resp.text,
+    )
     soup = BeautifulSoup(resp.text, "lxml")
     rows = soup.select("table.table tbody tr")
     return find_quota_for_date(rows, iso_date)

--- a/bot-semeru.py
+++ b/bot-semeru.py
@@ -286,6 +286,13 @@ def check_capacity(iso_date: str, site: str) -> dict | None:
 
         # Timeout tuple: (connect, read) → lebih responsif saat server lemot
         resp = sess.post(CAP_URL, data=payload, headers=headers, timeout=(7, 12))
+        log.info(
+            "check_capacity response (%s %s) status=%s body=%s",
+            site,
+            iso_date,
+            resp.status_code,
+            resp.text,
+        )
         # Bisa saja 200 tapi body kosong → anggap gagal
         if resp.status_code != 200 or not (resp.text or "").strip():
             log.warning("check_capacity: status=%s, empty=%s, site=%s, iso=%s",
@@ -1166,7 +1173,7 @@ async def poll_capacity_job(context: ContextTypes.DEFAULT_TYPE):
     chat_id = context.job.chat_id
 
     # --- DETEKSI INTERVAL AKTUAL DARI JOB (PTB v21: timedelta) ---
-    actual_interval = 20
+    actual_interval = 60
     try:
         if getattr(context.job, "interval", None):
             iv = context.job.interval  # timedelta
@@ -1175,7 +1182,7 @@ async def poll_capacity_job(context: ContextTypes.DEFAULT_TYPE):
         pass
 
     # --- PRIORITAS: pakai nilai yang dikirim lewat data, fallback ke interval aktual, lalu default ---
-    interval_seconds = int(data.get("interval_seconds") or actual_interval or 20)
+    interval_seconds = int(data.get("interval_seconds") or actual_interval or 60)
 
     # Kompatibilitas lama: kalau ada "notify_every" (dalam menit), konversi ke ticks
     if "notify_every_ticks" in data:


### PR DESCRIPTION
## Summary
- log HTTP status and body when checking quota for Bromo and Semeru
- increase polling interval for Semeru capacity checks to one minute

## Testing
- `python -m py_compile bot-bromo.py bot-semeru.py`
- `python - <<'PY'
import importlib.machinery, importlib.util
loader = importlib.machinery.SourceFileLoader('bot_semeru', 'bot-semeru.py')
spec = importlib.util.spec_from_loader(loader.name, loader)
mod = importlib.util.module_from_spec(spec)
loader.exec_module(mod)
print(mod.check_capacity('2025-10-01', 'semeru'))
PY`
- `python - <<'PY'
import importlib.machinery, importlib.util
loader = importlib.machinery.SourceFileLoader('bot_bromo', 'bot-bromo.py')
spec = importlib.util.spec_from_loader(loader.name, loader)
mod = importlib.util.module_from_spec(spec)
loader.exec_module(mod)
print(mod.check_capacity('2025-10-01'))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b562fe132c8322a74f527a0133abf9