### PR TITLE
Refine Semeru helper text and success message

### DIFF
--- a/bot-semeru.py
+++ b/bot-semeru.py
@@ -1444,14 +1444,14 @@ def do_booking_flow_semeru(
             extra_note += f"\n- (+{len(fail_msgs)-5} error lainnya)"
 
     # TAMPILKAN kode booking + shortcut command detail
-    # ganti '/detail_booking' jika command-mu bernama lain (mis. '/booking_detail')
-    cmd_hint = f"\nDetail cepat: <code>/detail_booking {booking_code}</code>" if booking_code else ""
+    # ganti '/booking_detail' jika command-mu bernama lain
+    cmd_hint = f"\n• Detail cepat: <code>/booking_detail {booking_code}</code>" if booking_code else ""
     msg = (
         "✅ Booking Semeru BERHASIL.\n"
-        f"Kode Booking: <code>{booking_code or '-'}</code>\n"
-        f"Link: {link}\n"
-        f"Anggota berhasil ditambahkan: {added} (di luar ketua)\n"
-        f"Server: {(data_do or {}).get('message','-')}"
+        f"• Kode Booking: <code>{booking_code or '-'}</code>\n"
+        f"• Link: {link}\n"
+        f"• Anggota berhasil ditambahkan: {added} (di luar ketua)\n"
+        f"• Pesan server: {(data_do or {}).get('message','-')}"
         f"{cmd_hint}"
         f"{extra_note}"
     )
@@ -1614,7 +1614,9 @@ HELP_TEXT = (
 
     "🏔️ <b>SEMERU</b>\n"
     "   • /book_semeru <tgl_booking>\n"
-    "   • /schedule_semeru <tgl_booking> <tgl_eksekusi> <HH:MM[:SS]>\n\n"
+    "     └─ contoh: <code>2025-09-30</code> | <code>30-09-2025</code> | <code>30 September 2025</code>\n"
+    "   • /schedule_semeru <tgl_booking> <tgl_eksekusi> <HH:MM[:SS]>\n"
+    "     └─ contoh: <code>/schedule_semeru 2025-09-30 2025-09-29 23:59</code>\n\n"
 
     "🗂️ <b>Manajemen Job</b>\n"
     "   • /jobs — daftar job\n"
@@ -1697,11 +1699,19 @@ async def examples_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
 
 async def start(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    await update.message.reply_text("Halo! Bot siap.\n\n" + HELP_TEXT)
+    await update.message.reply_text(
+        "Halo! Bot siap.\n\n" + HELP_TEXT,
+        parse_mode=ParseMode.HTML,
+        disable_web_page_preview=True,
+    )
 
 
 async def help_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    await update.message.reply_text(HELP_TEXT)
+    await update.message.reply_text(
+        HELP_TEXT,
+        parse_mode=ParseMode.HTML,
+        disable_web_page_preview=True,
+    )
 
 
 async def set_session(update: Update, context: ContextTypes.DEFAULT_TYPE):
@@ -1819,7 +1829,11 @@ async def book_confirm(update: Update, context: ContextTypes.DEFAULT_TYPE):
     extra = ""
     if raw:
         extra = f"\n\n[Server]\nmessage: {raw.get('message', '-')}\nlink: {raw.get('booking_link') or raw.get('link_redirect') or '-'}"
-    await update.message.reply_text(("✅ " if ok else "❌ ") + msg + f"\n\nWaktu proses: {elapsed_s:.2f} detik" + extra)
+    await update.message.reply_text(
+        ("✅ " if ok else "❌ ") + msg + f"\n\nWaktu proses: {elapsed_s:.2f} detik" + extra,
+        parse_mode=ParseMode.HTML,
+        disable_web_page_preview=True,
+    )
     return ConversationHandler.END
 
 
@@ -1967,7 +1981,9 @@ async def poll_capacity_job(context: ContextTypes.DEFAULT_TYPE):
 
     await context.bot.send_message(
         chat_id,
-        text=("[Polling] ✅ " if ok else "[Polling] ❌ ") + msg + f"\n\nWaktu proses: {elapsed_s:.2f} detik" + extra
+        text=("[Polling] ✅ " if ok else "[Polling] ❌ ") + msg + f"\n\nWaktu proses: {elapsed_s:.2f} detik" + extra,
+        parse_mode=ParseMode.HTML,
+        disable_web_page_preview=True,
     )
     context.job.schedule_removal()
 
@@ -2045,8 +2061,12 @@ async def scheduled_job(context: ContextTypes.DEFAULT_TYPE):
         server_msg = raw.get("message", "-")
         link = raw.get("booking_link") or raw.get("link_redirect") or "-"
         extra = f"\n[Server]\nmessage: {server_msg}\nlink: {link}"
-    await context.bot.send_message(chat_id, text=(
-                                                     "[Jadwal] ✅ " if ok else "[Jadwal] ❌ ") + msg + f"\n\nWaktu proses: {elapsed_s:.2f} detik" + extra)
+    await context.bot.send_message(
+        chat_id,
+        text=("[Jadwal] ✅ " if ok else "[Jadwal] ❌ ") + msg + f"\n\nWaktu proses: {elapsed_s:.2f} detik" + extra,
+        parse_mode=ParseMode.HTML,
+        disable_web_page_preview=True,
+    )
 
 
 async def reminder_job(context: ContextTypes.DEFAULT_TYPE):
@@ -2473,7 +2493,11 @@ async def book_semeru_confirm(update: Update, context: ContextTypes.DEFAULT_TYPE
     extra = ""
     if raw:
         extra = f"\n\n[Server]\nmessage: {raw.get('message', '-')}\nlink: {raw.get('booking_link') or raw.get('link_redirect') or '-'}"
-    await update.message.reply_text(("✅ " if ok else "❌ ") + msg + f"\n\nWaktu proses: {elapsed_s:.2f} detik" + extra)
+    await update.message.reply_text(
+        ("✅ " if ok else "❌ ") + msg + f"\n\nWaktu proses: {elapsed_s:.2f} detik" + extra,
+        parse_mode=ParseMode.HTML,
+        disable_web_page_preview=True,
+    )
     return ConversationHandler.END
 
 


### PR DESCRIPTION
## Summary
- add usage examples for `/book_semeru` and `/schedule_semeru` in help text
- clean up booking success message with bullet list and quick `/booking_detail` shortcut
- render helper and Semeru booking messages using HTML parse mode
- parse `/start` helper text using HTML to display bold formatting

## Testing
- `python -m py_compile bot-semeru.py bot-bromo.py`


------
https://chatgpt.com/codex/tasks/task_e_68b8f1150e148322a0854dbeefdaffbb