### PR TITLE
Add latency and speedtest commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ Skrip mencatat `latency.log` setiap 5 detik hanya pada jam rawan.
 ### Menggunakan perintah Telegram
 - Jalankan perintah `/monitor_latency` dari grup Telegram tempat bot berada.
 - Bot hanya menerima perintah ini di grup dan akan mengirim hasilnya ke grup yang sama.
+- Perintah `/ping` dapat digunakan kapan saja untuk mengecek latensi sekali (opsional sertakan host).
+- Jalankan `/speedtest` untuk mengukur kecepatan download/upload VPS tanpa terikat jam kritis.
 
 ## Tips Tambahan
 - Login ke akun pemesanan lebih awal untuk "pemanasan" koneksi.

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,6 @@ python-dotenv>=1.0.1
 # Optional but recommended: support 'br' / 'zstd' encodings if server mengirimnya
 brotlicffi>=1.1.0
 zstandard>=0.22.0
+
+# Network speed test
+speedtest-cli>=2.1.3,<3.0.0


### PR DESCRIPTION
## Summary
- add `/ping` command to check latency on demand
- add `/speedtest` command for download/upload benchmarks
- document new commands and include `speedtest-cli` dependency

## Testing
- `pip install speedtest-cli`
- `python -m py_compile bot-semeru.py monitor_latency.py`


------
https://chatgpt.com/codex/tasks/task_e_68ba903d2bc8832287ba3e626bd12d20