### PR TITLE
Fix member data retention in Semeru scheduler

### DIFF
--- a/bot-semeru.py
+++ b/bot-semeru.py
@@ -2735,12 +2735,18 @@ async def schedule_semeru_confirm(update: Update, context: ContextTypes.DEFAULT_
     for j in jq.get_jobs_by_name(job_name): j.schedule_removal()
     for j in jq.get_jobs_by_name(f"prewarm-{job_name}"): j.schedule_removal()
     for j in jq.get_jobs_by_name(f"view-{job_name}"): j.schedule_removal()
+    import copy
+    profile = {
+        "_leader": copy.deepcopy(context.user_data["_leader"]),
+        "_members": copy.deepcopy(context.user_data["_members"]),
+    }
+
     jobs_store = get_jobs_store(uid)
     jobs_store[job_name] = {
         "booking_iso": booking_iso,
         "exec_iso": exec_iso,
         "time": context.user_data["time"],
-        "profile": {"_leader": context.user_data["_leader"], "_members": context.user_data["_members"]},
+        "profile": profile,
         "cookies": context.user_data.get("cookies", {}),
         "reminder_minutes": context.user_data.get("reminder_minutes"),
         "created_at": datetime.now(ASIA_JAKARTA).isoformat(),
@@ -2748,10 +2754,19 @@ async def schedule_semeru_confirm(update: Update, context: ContextTypes.DEFAULT_
     }
     save_storage(storage)
 
-    jq.run_once(scheduled_job, when=run_at, name=job_name,
-                data={"user_id": uid, "site": "semeru", "iso": booking_iso,
-                      "profile": jobs_store[job_name]["profile"], "cookies": jobs_store[job_name]["cookies"]},
-                chat_id=update.effective_chat.id)
+    jq.run_once(
+        scheduled_job,
+        when=run_at,
+        name=job_name,
+        data={
+            "user_id": uid,
+            "site": "semeru",
+            "iso": booking_iso,
+            "profile": copy.deepcopy(profile),
+            "cookies": jobs_store[job_name]["cookies"],
+        },
+        chat_id=update.effective_chat.id,
+    )
 
     pre_at = run_at - timedelta(minutes=2)
     jq.run_once(prewarm_session_job, when=pre_at, name=f"prewarm-{job_name}",
@@ -2760,13 +2775,23 @@ async def schedule_semeru_confirm(update: Update, context: ContextTypes.DEFAULT_
                 chat_id=update.effective_chat.id)
     poll_start = run_at - timedelta(minutes=5)
     poll_end = run_at + timedelta(minutes=15)
-    jq.run_repeating(poll_get_view_job, interval=timedelta(seconds=5), first=poll_start,
-                     name=f"view-{job_name}",
-                     data={"job_name": job_name, "user_id": uid, "site": "semeru",
-                           "iso": booking_iso, "profile": jobs_store[job_name]["profile"],
-                           "cookies": jobs_store[job_name]["cookies"],
-                           "end_at": poll_end, "chat_id": update.effective_chat.id},
-                     chat_id=update.effective_chat.id)
+    jq.run_repeating(
+        poll_get_view_job,
+        interval=timedelta(seconds=5),
+        first=poll_start,
+        name=f"view-{job_name}",
+        data={
+            "job_name": job_name,
+            "user_id": uid,
+            "site": "semeru",
+            "iso": booking_iso,
+            "profile": copy.deepcopy(profile),
+            "cookies": jobs_store[job_name]["cookies"],
+            "end_at": poll_end,
+            "chat_id": update.effective_chat.id,
+        },
+        chat_id=update.effective_chat.id,
+    )
 
     remind_min = context.user_data.get("reminder_minutes")
     if isinstance(remind_min, int) and remind_min > 0:


### PR DESCRIPTION
## Summary
- Deep copy leader and member profiles when scheduling Semeru bookings to avoid later mutation
- Pass independent profile copies to monitoring jobs

## Testing
- `python -m py_compile bot-semeru.py`

------
https://chatgpt.com/codex/tasks/task_e_68bae19a386c8322933a5e50e2a7312a